### PR TITLE
fix: add root_url to grafana config that generated links do not include the internal port

### DIFF
--- a/serva/monitoring.nix
+++ b/serva/monitoring.nix
@@ -161,6 +161,7 @@
       };
       server = {
         domain = "grafana.pilz.foo";
+        root_url = "https://grafana.pilz.foo/";
         http_port = 3001;
         http_addr = "::1";
       };


### PR DESCRIPTION
https://search.nüschtos.de/?query=root_url&option_scope=11&option=services.grafana.settings.server.root_url

https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#root_url